### PR TITLE
fix: use the stable endpoint to avoid downtime

### DIFF
--- a/github_status_embed/types.py
+++ b/github_status_embed/types.py
@@ -186,7 +186,7 @@ class Webhook(TypedDataclass):
     @property
     def url(self) -> str:
         """Return the endpoint to execute this webhook."""
-        return f"https://canary.discord.com/api/webhooks/{self.id}/{self.token}"
+        return f"https://discord.com/api/webhooks/{self.id}/{self.token}"
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
discord canary sometimes is down
change the status embed to use stable so canary changes don't affect the worker